### PR TITLE
Added a basic fabfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dropin.cache
 _trial_temp
 twistd.pid
+virtualenv/

--- a/README
+++ b/README
@@ -1,11 +1,35 @@
 An AI space fighting playground.
 
-you can use the scripts to start a server, some clients and some monitors.
+you can use fabric to do pretty much anything there is to do currently:
 
-run tests with
-$ trial spacecraft
+To run the tests
+================
+$ fab test
 
-TODO:
+
+To start a server
+=================
+$ fab run_server
+Extra arguments can be passed into this command in two different (ugly) ways:
+$ fab run_server:--xsize,1234
+or:
+$ fab "run_server:--xsize 1234"
+
+
+To start a client
+=================
+$ fab run_client
+You can start more than one client at a time
+
+
+To start a monitor
+==================
+$ fab run_monitor
+Like with clients, you can start more than one monitor at a time.
+
+
+TODO
+====
 - everything
 - wraparound
 - bullets

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+from fabric.api import local
+
+
+def bootstrap():
+    check_system_deps()
+    virtualenv_create()
+    install_requirements()
+
+
+def run_server(*args):
+    check_bootstrap()
+    local('./virtualenv/bin/twistd -n spacecraft %s' % ' '.join(args))
+
+
+def run_client():
+    check_bootstrap()
+    local('PYTHONPATH=. ./virtualenv/bin/python spacecraft/client.py')
+
+
+def run_monitor():
+    check_bootstrap()
+    local('PYTHONPATH=. ./virtualenv/bin/python spacecraft/monitor.py')
+
+
+def clean():
+    local("rm -rf virtualenv")
+
+
+def test():
+    check_bootstrap()
+    local('./virtualenv/bin/trial spacecraft')
+
+# -----------------------------------------------------------------
+# Tasks from here down aren't intended to be used directly
+
+
+def virtualenv_create():
+    local("rm -rf virtualenv")
+    local("%s /usr/bin/virtualenv virtualenv" % sys.executable, capture=False)
+
+
+def check_system_deps():
+    system_deps = ['pygame']
+    missing_deps = []
+    for dep in system_deps:
+        result = local('''%s -c "try:
+    import %s
+except ImportError:
+    print ':('
+"''' % (sys.executable, dep), capture=True)
+        if result:
+            missing_deps.append(dep)
+    if missing_deps:
+        print "Please install the following deps on your system:"
+        print '\n'.join(' * %s' % x for x in missing_deps)
+
+
+def install_requirements():
+    local("virtualenv/bin/pip install -r requirements.txt", capture=False)
+
+
+def check_bootstrap():
+    if not os.path.isdir('virtualenv'):
+        bootstrap()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+svn+http://pybox2d.googlecode.com/svn/trunk/
+twisted==10.1.0

--- a/run_client.sh
+++ b/run_client.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-PYTHONPATH=. python spacecraft/client.py

--- a/run_monitor.sh
+++ b/run_monitor.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-PYTHONPATH=. python spacecraft/monitor.py

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,2 +1,0 @@
-#/bin/sh
-twistd -n spacecraft $*


### PR DESCRIPTION
The fabfile this branch brings includes the following jobs:
- run_server
- run_client
- run_monitor
- test
- bootstrap
- clean

Every job (except clean) checks if the branch has been bootstrapped already and runs the bootstrap job if not, so you can now just clone the repo and run "fab test" to get the tests to run.

Some deps need to be installed system-wide, currenly only pygame, as it's a hassle to build them locally and usually very simple to install from your system repo.  Bootstrap will just check if these are installed, and bail out with a message if not.
